### PR TITLE
Fix input display of error with label

### DIFF
--- a/src/shared/ui/input/index.module.scss
+++ b/src/shared/ui/input/index.module.scss
@@ -167,6 +167,11 @@
     font: var(--font-s);
     color: #848484;
   }
+
+  .errorContainer,
+  .tooltip {
+    margin-top: 28px;
+  }
 }
 
 .file {


### PR DESCRIPTION
Before:
![image](https://github.com/crowdparlay/frontend/assets/44271343/04479e29-f83d-46f1-89ce-2bf2cde057d1)

After:
![image](https://github.com/crowdparlay/frontend/assets/44271343/166aad50-3155-434b-a528-d929daff4d20)
