### PR TITLE
Fix profile preview

### DIFF
--- a/src/features/avatar/index.module.scss
+++ b/src/features/avatar/index.module.scss
@@ -5,6 +5,7 @@
   height: $size;
   border-radius: 6px;
   display: flex;
+  flex: none;
   align-items: center;
   justify-content: center;
   font: var(--font-l);
@@ -13,11 +14,6 @@
   transition: 500ms ease-out;
   -webkit-touch-callout: none;
   user-select: none;
-  container-type: inline-size;
-
-  p {
-    font-size: 60cqw;
-  }
 }
 
 .light {

--- a/src/features/avatar/index.tsx
+++ b/src/features/avatar/index.tsx
@@ -53,7 +53,26 @@ export const Avatar = (props: AvatarProps) => {
       className={classNames(cls.avatar, mods, className)}
       {...otherProps}
     >
-      <p>{displayName[0]?.toUpperCase() ?? 'D'}</p>
+      <svg
+        width="100%"
+        height="100%"
+        viewBox="0 0 40 40"
+        preserveAspectRatio="xMinYMid meet"
+        xmlns="http://www.w3.org/2000/svg"
+        // @ts-ignore
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+      >
+        <text
+          x="50%"
+          y="54%"
+          font-size="24"
+          dominant-baseline="middle"
+          text-anchor="middle"
+          fill="currentColor"
+        >
+          {displayName[0]?.toUpperCase() ?? 'D'}
+        </text>
+      </svg>
     </div>
   );
 };

--- a/src/features/profile-preview/index.module.scss
+++ b/src/features/profile-preview/index.module.scss
@@ -1,9 +1,12 @@
 .preview {
+  overflow: hidden;
   display: flex;
+  width: 100%;
   gap: 11px;
 }
 
 .list {
+  overflow: hidden;
   display: flex;
   flex-direction: column;
   gap: 1px;
@@ -15,10 +18,12 @@
   align-items: center;
 }
 
-.name {
+.wrapText {
   overflow: hidden;
-  color: var(--color-white);
-  max-width: 299px;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.name {
+  color: var(--color-white);
 }

--- a/src/features/profile-preview/index.tsx
+++ b/src/features/profile-preview/index.tsx
@@ -26,7 +26,7 @@ export const ProfilePreview = (props: ProfilePreviewProps) => {
       <Avatar username={username} displayName={displayName} avatarUrl={avatarUrl} />
       <div className={cls.list}>
         <div className={cls.nameContainer}>
-          <Text className={classNames(cls.name, cls.maxWidth)}>
+          <Text className={classNames(cls.name, cls.wrapText)}>
             {displayName || 'Display name'}
           </Text>
 
@@ -35,7 +35,7 @@ export const ProfilePreview = (props: ProfilePreviewProps) => {
         {showDate && date ? (
           <Text size={TextSize.S}>{date.toLocaleTimeString()}</Text>
         ) : (
-          <Text className={cls.maxWidth} size={TextSize.S}>
+          <Text className={cls.wrapText} size={TextSize.S}>
             @{username || 'username'}
           </Text>
         )}


### PR DESCRIPTION
Added Firefox support for Avatar preview (replacing text element with svg) with support for resizing

https://github.com/crowdparlay/frontend/assets/44271343/58c02d8a-3ccb-4782-9855-5e831cc141c5

Refactor profile-preview: replace magic max-width (299px) with full container size
